### PR TITLE
fix bug when there are '\r\n' strings in Lua mode

### DIFF
--- a/lib/ace/mode/lua/luaparse.js
+++ b/lib/ace/mode/lua/luaparse.js
@@ -1935,6 +1935,7 @@ define(function(require, exports, module) {
     if (!_options) _options = {};
 
     input = _input || '';
+    input = input.replace(/\r\n/g, '\n');
     options = extend(defaultOptions, _options);
 
     // Rewind the lexer


### PR DESCRIPTION
when I use `http://localhost:8888/kitchen-sink.html` to open a Lua code which contains `\r\n` strings, error report in wrong line.

this error maybe caused by code like this:
```
if (isLineTerminator(charCode)) {
        line++;
        ...
```